### PR TITLE
ActiveRecord instead of array

### DIFF
--- a/Widget.php
+++ b/Widget.php
@@ -45,7 +45,7 @@ class Widget extends InputWidget
 
         $this->attributes = $this->model->attributes();
 
-        $data = ($this->data) ? $this->data->asArray()->all() : [];
+        $data = ($this->data) ? $this->data->all() : [];
 
         echo '<div id="'.$inputId.'" >';
 
@@ -54,14 +54,13 @@ class Widget extends InputWidget
         $cnt = 0;
         foreach ($data as $key => $value) {
 
-            if (!in_array($value[$this->data_id], $selected)) {
-                $ret .= '<option value="' . $value[$this->data_id] . '">' . $value[$this->data_value] . '</option>' . "\n";
+            if (!in_array($value->{$this->data_id}, $selected)) {
+                $ret .= '<option value="' . $value->{$this->data_id} . '">' . $value->{$this->data_value} . '</option>' . "\n";
         } else {
                 $cnt++;
                 $ret_sel .= '$("#dlb-'.$this->attribute.' .selected").
-                append("<option value=' . $value[$this->data_id] . '>' . $value[$this->data_value] . '</option>");';
+                append("<option value=' . $value->{$this->data_id} . '>' . $value->{$this->data_value} . '</option>");';
             }
-
         }
         $ret .= '</select>';
 


### PR DESCRIPTION
Changed data type from array to ActiveRecord object to make it possible to use getters for data_id and data_value. Although array's are more efficient the loss of functionality does warrant to use Activerecord.
